### PR TITLE
Solving conversion of number values with ".".

### DIFF
--- a/IO/Xml/XmlExtensions.cs
+++ b/IO/Xml/XmlExtensions.cs
@@ -108,11 +108,11 @@ namespace MegaMan.IO.Xml
             var underlyingType = Nullable.GetUnderlyingType(typeof(T));
             if (underlyingType != null)
             {
-                return (T)Convert.ChangeType(value, underlyingType);
+                return (T)Convert.ChangeType(value, underlyingType, System.Globalization.CultureInfo.InvariantCulture);
             }
             else
             {
-                return (T)Convert.ChangeType(value, typeof(T));
+                return (T)Convert.ChangeType(value, typeof(T), System.Globalization.CultureInfo.InvariantCulture);
             }
         }
     }


### PR DESCRIPTION
Conversion of numbers with "." was not working if loading the project in a region that uses "," instead.

This problem was in the following function: private static T ConvertValue<T>(string value)

Now when calling Conver.ChangeType, the following parameter is passed, which allows the conversion no matter of the region.