### PR TITLE
Update MainForm.cs

### DIFF
--- a/Mega Man/Forms/MainForm.cs
+++ b/Mega Man/Forms/MainForm.cs
@@ -68,6 +68,20 @@ namespace MegaMan.Engine
 
             ResizeScreen();
         }
+        
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            
+            if (WindowState == FormWindowState.Minimized)
+            {
+                Engine.Instance.Stop();
+            }
+            else
+            {
+                Engine.Instance.Start();
+            }
+        }
 
         protected override void OnDeactivate(EventArgs e)
         {

--- a/Mega Man/Forms/MainForm.cs
+++ b/Mega Man/Forms/MainForm.cs
@@ -396,6 +396,7 @@ namespace MegaMan.Engine
 
         private void ScreenSizeMultiple()
         {
+            WindowState = FormWindowState.Normal;
             if (Game.CurrentGame == null)
             {
                 DefaultScreen();

--- a/Mega Man/Game.cs
+++ b/Mega Man/Game.cs
@@ -113,14 +113,14 @@ namespace MegaMan.Engine
 
             BasePath = project.BaseDir;
 
-            PixelsDown = project.ScreenHeight;
-            PixelsAcross = project.ScreenWidth;
-
-            if (ScreenSizeChanged != null)
-            {
-                ScreenSizeChangedEventArgs args = new ScreenSizeChangedEventArgs(PixelsAcross, PixelsDown);
-                ScreenSizeChanged(this, args);
-            }
+            //PixelsDown = project.ScreenHeight;
+            //PixelsAcross = project.ScreenWidth;
+            //
+            //if (ScreenSizeChanged != null)
+            //{
+            //    ScreenSizeChangedEventArgs args = new ScreenSizeChangedEventArgs(PixelsAcross, PixelsDown);
+            //    ScreenSizeChanged(this, args);
+            //}
 
             if (project.MusicNSF != null) Engine.Instance.SoundSystem.LoadMusicNSF(project.MusicNSF.Absolute);
             if (project.EffectsNSF != null) Engine.Instance.SoundSystem.LoadSfxNSF(project.EffectsNSF.Absolute);


### PR DESCRIPTION
- Trello card: even-if-engine-doesn-t-have-focus-if-pressing-a-key-like-enter-the-engine-will-respond

Problem occured because when program is minimised while clicking on the icon in the system tray, the event that minimizes the form doesn't call the activate/deactivate event from the form load, which are the ones that pause the engine. Same logic applies when clicking on this icon to activate program.

Needed to add code that is sure to be executed when program is minimized/maximized this way.

This function was added: protected override void OnResize(EventArgs e)

Sometime this code will be called to stop engine with OnDeactivate or OnActivated method. This is however the best method I found to be sure engine is activated/deactivated every time it needs to be.